### PR TITLE
fix/using-argument-position-instead-of-global-state-target-position

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
@@ -546,7 +546,7 @@ public class CardStackLayoutManager
             state.proportion = 0.0f;
             state.targetPosition = position;
             CardStackSmoothScroller scroller = new CardStackSmoothScroller(CardStackSmoothScroller.ScrollType.AutomaticSwipe, this);
-            scroller.setTargetPosition(state.topPosition);
+            scroller.setTargetPosition(position);
             startSmoothScroll(scroller);
         }
     }


### PR DESCRIPTION
I am gonna try to use the position that we previously checked before instead of the global target position. 

I feel like that position is being being changed in another place when we perform startSmoothScroll()

![image](https://github.com/user-attachments/assets/c0d762b8-fac6-4887-9e05-248da7ace4ca)
